### PR TITLE
Set Vite base to "/akkey-simurator/" for correct asset paths

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  base: "/akkey-simurator/",
   plugins: [react()],
 });


### PR DESCRIPTION
### Motivation
- Ensure built assets are referenced under the `/akkey-simurator/` subpath (for example, GitHub Pages deployment) so routes and static files load correctly.

### Description
- Add `base: "/akkey-simurator/"` to `vite.config.ts` to configure the app base path for production builds.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c55f3bf4832ca2a0f589e2655b1a)