### PR TITLE
Add GitHub Pages deploy workflow and set Vite base path

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  base: "/akkey-simurator/",
   plugins: [react()],
 });


### PR DESCRIPTION
### Motivation
- Enable automated deployment of the built site to GitHub Pages and ensure assets are served from the repository subpath.
- Ensure the Vite build emits URLs that match the Pages site path to avoid broken asset links.

### Description
- Added `.github/workflows/deploy-pages.yml` to build and deploy the site on pushes to `main`/`master` and via `workflow_dispatch`, using `actions/checkout@v4`, `actions/setup-node@v4`, `npm ci`, `npm run build`, `actions/upload-pages-artifact@v3`, and `actions/deploy-pages@v4` with a `pages` concurrency group and appropriate permissions.
- Updated `vite.config.ts` to set the `base` option to `"/akkey-simurator/"` so the generated assets reference the correct repository path.

### Testing
- No automated tests were executed as part of this change; the workflow will run `npm run build` and deploy when triggered in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c55f3bf4832ca2a0f589e2655b1a)